### PR TITLE
Problem: main upses are in all asset messages

### DIFF
--- a/src/fty_asset_server.cc
+++ b/src/fty_asset_server.cc
@@ -322,7 +322,8 @@ static void
             zhash_insert (aux, "type", (void*) asset_type2str (foo_i));
                   
             // additional aux items (requiered by uptime)
-            insert_upses_to_aux (aux, asset_name);
+            if (streq (asset_type2str (foo_i), "datacenter"))
+                insert_upses_to_aux (aux, asset_name);
                        
             foo_i = 0;
             row ["subtype_id"].get (foo_i);


### PR DESCRIPTION
Solution: put it to datacenter inventory message only

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>