### PR TITLE
Do not check mysql_affected_rows when updating an asset

### DIFF
--- a/src/dbhelpers.cc
+++ b/src/dbhelpers.cc
@@ -696,17 +696,12 @@ db_reply_t
             // also set name to fty_proto
             fty_proto_set_name (fmsg, "%s-%" PRIu64, element_name, ret.rowid);
         }
-        if (ret.affected_rows == 0) {
-            ret.status = 0;
-            //TODO: rework to bad param
-            // bios_error_idx(ret.rowid, ret.msg, "data-conflict", element_name, "Most likely duplicate entry.");
-        }
-        else {
-            // went well some lines changed
+        if (ret.affected_rows == 0)
+            zsys_debug ("Asset unchanged, processing inventory");
+        else
             zsys_debug ("Insert went well, processing inventory.");
-            process_insert_inventory (fty_proto_name (fmsg), fty_proto_ext (fmsg), false);
-            ret.status = 1;
-        }
+        process_insert_inventory (fty_proto_name (fmsg), fty_proto_ext (fmsg), false);
+        ret.status = 1;
         return ret;
     }
     catch (const std::exception &e) {


### PR DESCRIPTION
The INSERT INTO ... ON DUPLICATE KEY UPDATE can legitimately result in 0
affected rows if the new values are identical to an existing row (cf.
https://dev.mysql.com/doc/refman/5.7/en/mysql-affected-rows.html). It
turns out, tntdb checks for real mysql errors and throws an exception
which we handle, so just remove the check. This fixes BIOS-4179.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>