### PR TITLE
Problem: When using ASSET_MANIPULATION, all ext attributes are stored…

### DIFF
--- a/src/dbhelpers.h
+++ b/src/dbhelpers.h
@@ -225,6 +225,7 @@ FTY_ASSET_PRIVATE int
     process_insert_inventory
     (const std::string& device_name,
     zhash_t *ext_attributes,
+    bool read_only,
     bool test);
 
 // Selects user-friendly name for given asset name
@@ -242,6 +243,7 @@ void
 FTY_ASSET_PRIVATE db_reply_t
     create_or_update_asset
     (fty_proto_t *fmsg,
+     bool read_only,
      bool test);
 //  @end
 

--- a/src/fty_asset_inventory.cc
+++ b/src/fty_asset_inventory.cc
@@ -120,7 +120,7 @@ fty_asset_inventory_server (zsock_t *pipe, void *args)
             const char *operation = fty_proto_operation(proto);
 
             if (streq (operation, "inventory")) {
-                int rv = process_insert_inventory (device_name, ext, test);
+                int rv = process_insert_inventory (device_name, ext, true, test);
                 if (rv != 0)
                     zsys_error ("Could not insert inventory data into DB");
             }


### PR DESCRIPTION
… as readonly.

Solution: Add READONLY/READWRITE frame to ASSET_MANIPULATION message, let the info trickle down to process_insert_inventory() which needs it.

Signed-off-by: Jana Rapava <janarapava@eaton.com>