### PR TITLE
Fix possible uncaught exception while converting from fty_proto_t to fty::Asset

### DIFF
--- a/src/dbhelpers.cc
+++ b/src/dbhelpers.cc
@@ -554,4 +554,6 @@ void updateAssetExtProperties(const fty::Asset& asset)
             set ("readonly", readOnly).
             execute ();
     }
+
+    trans.commit();
 }

--- a/src/fty_asset_manipulation.cc
+++ b/src/fty_asset_manipulation.cc
@@ -255,7 +255,15 @@ fty_proto_t * assetToFtyProto(const fty::Asset& asset, const std::string& operat
     }
     else
     {
-        zhash_insert(aux, "parent", const_cast<void *>(reinterpret_cast<const void *>(std::to_string(selectAssetProperty<int>("id_parent", "name", asset.getInternalName())).c_str())));
+        std::string parentIname = asset.getInternalName();
+        if(!parentIname.empty())
+        {
+            zhash_insert(aux, "parent", const_cast<void *>(reinterpret_cast<const void *>(std::to_string(selectAssetProperty<int>("id_parent", "name", asset.getInternalName())).c_str())));
+        }
+        else
+        {
+            zhash_insert(aux, "parent", const_cast<void *>(reinterpret_cast<const void *>("0")));
+        }
     }
     zhash_insert(aux, "status", const_cast<void *>(reinterpret_cast<const void *>(assetStatusToString(asset.getAssetStatus()).c_str())));
 
@@ -288,7 +296,15 @@ fty::Asset ftyProtoToAsset(fty_proto_t * proto, bool extAttributeReadOnly, bool 
     }
     else
     {
-        asset.setParentIname(selectAssetProperty<std::string>("name", "id_parent", fty_proto_aux_number(proto, "parent", 0)));
+        int parentId = fty_proto_aux_number(proto, "parent", 0);
+        if(parentId != 0)
+        {
+            asset.setParentIname(selectAssetProperty<std::string>("name", "id_parent", parentId));
+        }
+        else
+        {
+            asset.setParentIname("");
+        }
     }
     asset.setPriority(fty_proto_aux_number(proto, "priority", 5));
 

--- a/src/fty_asset_server.cc
+++ b/src/fty_asset_server.cc
@@ -1036,13 +1036,13 @@ static void
 
     // get operation from message
     const char *operation = fty_proto_operation (fmsg);
-
-    // get asset from fty-proto
-    fty::Asset asset;
-    asset = ftyProtoToAsset(fmsg, read_only, cfg->test);
-
+    
     try
     {
+        // get asset from fty-proto
+        fty::Asset asset;
+        asset = ftyProtoToAsset(fmsg, read_only, cfg->test);
+
         // asset manipulation is disabled
         if(cfg->limitations.global_configurability == 0)
         {


### PR DESCRIPTION
Conversion from fty_proto to fty::Asset requires access to database to retrieve parent iname of asset.
In case parent ID is not present, database should not be queried.

- added check to avoid querying database when parent ID is not known
- move conversion from fty_proto to fty::Asset into try...catch block

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>