### PR TITLE
Fix fty-asset failures trying to update rackcontroller-0

### DIFF
--- a/src/fty_asset_autoupdate.cc
+++ b/src/fty_asset_autoupdate.cc
@@ -205,7 +205,7 @@ autoupdate_request_all_rcs (fty_asset_autoupdate_t *self)
     zmsg_t *msg = zmsg_new ();
     zmsg_addstr (msg, "GET");
     zmsg_addstr (msg, "");
-    zmsg_addstr (msg, "rackcontroller");
+    zmsg_addstr (msg, "rack controller");
     int rv = mlm_client_sendto (self->client, self->asset_agent_name, "ASSETS_IN_CONTAINER", NULL, 5000, &msg);
     if (rv != 0) {
         log_error ("%s:\tRequest RC list failed", self->name);

--- a/src/fty_asset_server.cc
+++ b/src/fty_asset_server.cc
@@ -959,6 +959,10 @@ static void s_handle_subject_asset_manipulation(const fty::AssetServer& server, 
         fty::AssetImpl asset;
 
         fty::conversion::fromFtyProto(proto, asset, read_only, server.getTestMode());
+        log_debug("s_handle_subject_asset_manipulation(): Processing operation '%s' "
+            "for asset named '%s' with type '%s' and subtype '%s'",
+            operation, asset.getInternalName().c_str(),
+            asset.getAssetType().c_str(), asset.getAssetSubtype().c_str());
 
         if (streq(operation, "create") || streq(operation, "create-force")) {
             bool requestActivation = (asset.getAssetStatus() == fty::AssetStatus::Active);
@@ -995,6 +999,7 @@ static void s_handle_subject_asset_manipulation(const fty::AssetServer& server, 
             fty::AssetImpl currentAsset(asset.getInternalName());
             // force ID of asset to update
             asset.setId(currentAsset.getId());
+            log_debug("s_handle_subject_asset_manipulation(): Updating asset with DB ID '%" PRIu32 "'", asset.getId());
 
             bool requestActivation = (currentAsset.getAssetStatus() == fty::AssetStatus::Nonactive &&
                                       asset.getAssetStatus() == fty::AssetStatus::Active);

--- a/src/fty_asset_server.cc
+++ b/src/fty_asset_server.cc
@@ -993,6 +993,8 @@ static void s_handle_subject_asset_manipulation(const fty::AssetServer& server, 
             server.sendNotification(notification);
         } else if (streq(operation, "update")) {
             fty::AssetImpl currentAsset(asset.getInternalName());
+            // force ID of asset to update
+            asset.setId(currentAsset.getId());
 
             bool requestActivation = (currentAsset.getAssetStatus() == fty::AssetStatus::Nonactive &&
                                       asset.getAssetStatus() == fty::AssetStatus::Active);


### PR DESCRIPTION
* Update codepath gets called without the entry ID to update
* Match "rack controller" subtype to what is used in database (see also https://github.com/42ity/fty-common/pull/111)
* Add a bit of debug logs