### PR TITLE
Fix fty-proto to fty::Asset conversion

### DIFF
--- a/server/src/asset/conversion/proto.cc
+++ b/server/src/asset/conversion/proto.cc
@@ -58,10 +58,14 @@ namespace fty { namespace conversion {
         } else {
             std::string parentIname = asset.getInternalName();
             if (!parentIname.empty()) {
-                std::string parentId =
-                    std::to_string(selectAssetProperty<int>("id_parent", "name", asset.getInternalName()));
-                zhash_insert(
-                    aux, "parent", const_cast<void*>(reinterpret_cast<const void*>(parentId.c_str())));
+                std::string parentId;
+                try {
+                    parentId = std::to_string(selectAssetProperty<int>("id_parent", "name", asset.getInternalName()));
+                    zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>(parentId.c_str())));
+                } catch (const std::exception& e) {
+                    log_error("Parent ID not found in database");
+                    zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>("0")));
+                }
             } else {
                 zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>("0")));
             }
@@ -95,7 +99,10 @@ namespace fty { namespace conversion {
         if (test) {
             asset.setParentIname("test-parent");
         } else {
-            asset.setParentIname(fty_proto_aux_string(proto, "parent", ""));
+            std::string parentId(fty_proto_aux_string(proto, "parent", ""));
+            if(parentId != "0") {
+                asset.setParentIname(parentId);
+            }
         }
         asset.setPriority(static_cast<int>(fty_proto_aux_number(proto, "priority", 5)));
 

--- a/server/src/dbhelpers.h
+++ b/server/src/dbhelpers.h
@@ -135,20 +135,14 @@ TypeRet selectAssetProperty(
 
     tntdb::Connection conn = tntdb::connectCached (DBConn::url);
 
-    auto q = conn.prepareCached (query.str());
+    TypeRet obj;
 
+    auto q = conn.prepareCached (query.str());
     q.set ("value", keyValue);
 
-    TypeRet obj;
-    try {
-        auto row = q.selectRow();
+    auto row = q.selectRow();
 
-        row[0].get(obj);
-    } catch (const tntdb::NotFound&) {
-        log_debug("selectAssetProperty - value not found. Returning default value");
-    } catch (const std::exception& e) {
-        log_error("selectAssetProperty - unknown error: %s", e.what());
-    }
+    row[0].get(obj);
 
     return obj;
 }
@@ -173,15 +167,9 @@ const TypeRet selectAssetPropertyLike(
     TypeRet obj;
 
     auto q = conn.prepareCached(query.str());
-    try {
-        auto row = q.selectRow();
+    auto row = q.selectRow();
 
-        row[0].get(obj);
-    } catch (const tntdb::NotFound&) {
-        log_debug("selectAssetPropertyLike - value not found. Returning default value");
-    } catch (const std::exception& e) {
-        log_error("selectAssetPropertyLike - unknown error: %s", e.what());
-    }
+    row[0].get(obj);
 
     return obj;
 }


### PR DESCRIPTION
- the parent ID is set to NULL in database when receiving 0 in fty-proto encoding

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>