### PR TITLE
Fix parent ID to parent iname when converting fty-proto to fty::Asset

### DIFF
--- a/server/src/asset/conversion/proto.cc
+++ b/server/src/asset/conversion/proto.cc
@@ -56,15 +56,13 @@ namespace fty { namespace conversion {
         if (test) {
             zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>("0")));
         } else {
-            std::string parentIname = asset.getInternalName();
-            if (!parentIname.empty()) {
-                std::string parentId;
+            if (!asset.getParentIname().empty()) {
                 try {
-                    parentId = std::to_string(selectAssetProperty<int>("id_parent", "name", asset.getInternalName()));
+                    std::string parentId = std::to_string(selectAssetProperty<int>("id_asset_element", "name", asset.getParentIname()));
                     zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>(parentId.c_str())));
                 } catch (const std::exception& e) {
-                    log_error("Parent ID not found in database");
-                    zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>("0")));
+                    log_error("Invalid conversion from Asset to fty_proto_t : %s", e.what());
+                    throw std::runtime_error("Invalid conversion from Asset to fty_proto_t : " + std::string(e.what()));
                 }
             } else {
                 zhash_insert(aux, "parent", const_cast<void*>(reinterpret_cast<const void*>("0")));
@@ -101,7 +99,14 @@ namespace fty { namespace conversion {
         } else {
             std::string parentId(fty_proto_aux_string(proto, "parent", ""));
             if(parentId != "0") {
-                asset.setParentIname(parentId);
+                std::string parentIname;
+                try {
+                    parentIname = selectAssetProperty<std::string>("name", "id_asset_element", parentId);
+                    asset.setParentIname(parentIname);
+                } catch (const std::exception& e) {
+                    log_error("Invalid conversion from fty_proto_t to Asset: %s", e.what());
+                    throw std::runtime_error("Invalid conversion from fty_proto_t to Asset: " + std::string(e.what()));
+                }
             }
         }
         asset.setPriority(static_cast<int>(fty_proto_aux_number(proto, "priority", 5)));


### PR DESCRIPTION
- fix conversion error
- improve logging

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>