### PR TITLE
Increase fty-asset SRR version

### DIFF
--- a/server/src/asset-server.cc
+++ b/server/src/asset-server.cc
@@ -986,7 +986,7 @@ void AssetServer::restoreAssets(const cxxtools::SerializationInfo& si, bool tryA
     std::string srrVersion;
     si.getMember("version") >>= srrVersion;
 
-    if (srrVersion != SRR_ACTIVE_VERSION) {
+    if (fty::convert<float>(srrVersion) > fty::convert<float>(SRR_ACTIVE_VERSION)) {
         throw std::runtime_error("Version " + srrVersion + " is not supported");
     }
 

--- a/server/src/asset-server.h
+++ b/server/src/asset-server.h
@@ -62,7 +62,7 @@ static constexpr const char* METADATA_ID_ONLY           = "ID_ONLY";
 static constexpr const char* METADATA_WITH_PARENTS_LIST = "WITH_PARENTS_LIST";
 
 // SRR
-static constexpr const char* SRR_ACTIVE_VERSION  = "1.0";
+static constexpr const char* SRR_ACTIVE_VERSION  = "1.1";
 static constexpr const char* FTY_ASSET_SRR_AGENT = "asset-agent-srr";
 static constexpr const char* FTY_ASSET_SRR_NAME  = "asset-agent";
 static constexpr const char* FTY_ASSET_SRR_QUEUE = "FTY.Q.ASSET.SRR";


### PR DESCRIPTION
Increase SRR version to prevent restore of new asset types on older versions

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>