### PR TITLE
Ensure that returned errors are user-friendly

### DIFF
--- a/asset/asset/error.h
+++ b/asset/asset/error.h
@@ -31,7 +31,7 @@ inline Translate error(Errors err)
     case Errors::BadRequestDocument:
         return "Request document has invalid syntax. {}"_tr;
     case Errors::ActionForbidden:
-        return "{} is forbidden. {}"_tr;
+        return "{} is forbidden: {}"_tr;
     case Errors::ElementNotFound:
         return "Element '{}' not found."_tr;
     case Errors::ElementAlreadyExist:

--- a/asset/src/asset-import.cpp
+++ b/asset/src/asset-import.cpp
@@ -716,7 +716,7 @@ AssetExpected<db::AssetElement> Import::processRow(
                     std::string assetJson = getJsonAsset(el.id);
                     if (auto res = activation::activate(assetJson); !res) {
                         logError("Error during asset activation - {}", res.error());
-                        return unexpected("licensing-err", res.error());
+                        return unexpected(res.error());
                     }
                 }
             } else {
@@ -776,7 +776,7 @@ AssetExpected<db::AssetElement> Import::processRow(
                     std::string assetJson = getJsonAsset(el.id);
                     if (auto res = activation::activate(assetJson); !res) {
                         logError("Error during asset activation - {}", res.error());
-                        return unexpected("licensing-err", res.error());
+                        return unexpected(res.error());
                     }
                 }
             } else {

--- a/asset/src/asset-import.cpp
+++ b/asset/src/asset-import.cpp
@@ -177,7 +177,7 @@ AssetExpected<void> Import::process(bool checkLic)
         }
         else if (!limitations->global_configurability) {
             return unexpected(error(Errors::ActionForbidden)
-                   .format("Asset handling"_tr, "Licensing global_configurability limit hit"_tr));
+                   .format("Asset handling"_tr, "license has expired"_tr));
         }
     }
 


### PR DESCRIPTION
In case of insufficient node credits or expired license, the returned errors are generic and not self explanatory

Ref: IPMVAL-3964

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>